### PR TITLE
Change ORDER to FALSE

### DIFF
--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -176,7 +176,7 @@ class Dictionary extends Repository implements DictionaryInterface
      */
     protected function getFiles(): array
     {
-        $ressources = $this->locator->listResources($this->uri.$this->locale->getIdentifier(), true);
+        $ressources = $this->locator->listResources($this->uri.$this->locale->getIdentifier(), true, false);
         $ressources = array_reverse($ressources);
 
         return $ressources;


### PR DESCRIPTION
Sprinkles loades in alphabetic order, so new sprinkles not loaded in the correct order. Set this to false and all new sprinkles are loaded correctly, changing previous Key => Values